### PR TITLE
FIX ERROR WHEN CREATING A NEW 'Admin' WITHOUT AN 'admins' TABLE IN DB

### DIFF
--- a/bin/utils.js
+++ b/bin/utils.js
@@ -30,6 +30,7 @@ async function tryToCreateNewAdmin() {
   const database = new Sequelize(databaseUrl, databaseConfig)
   const adminModel = await Admin(database)
   const adminInfo = await getAdminInfo()
+  await createTableIfNotExist(adminModel)
   const { username } = await adminModel.create(adminInfo)
   logToConsoleAdminWasSuccessfullyCreated(username)
 }
@@ -85,6 +86,14 @@ function hashSuperUsersPassword(superUserPassword) {
  */
 function exitApplication() {
   process.exit()
+}
+
+/**
+ * @summary creates the Admin table in the DB if it does not exist
+ * @return void
+ */
+async function createTableIfNotExist(model) {
+  await model.sync()
 }
 
 /**


### PR DESCRIPTION
- bin/utils.js

<!-- Remove any unused sections before submitting a pull request -->

### PR Check list
- [x] I am pulling from my own branch and **not** a master branch
- [x] My branch is named appropriately: e.g. `bbenefield89/unit_tests`
- [x] Commit messages are detailed and reference file(s) changed


### Pull Request Description
<!-- Short description about this pull request -->
<!-- If your pull request is in reference to an open issue please add that in the description -->
Using the CLI and creating a new Admin without an `admins` table in the DB would throw an error.

This PR makes it so the CLI will first check if the `admins` table exists and create one if it does not before attempting to insert a new Admin.

### Screenshots
<!-- If a screen short adds value then feel free to attach one here -->