### PR TITLE
Bbenefield89/hide fields from ui

### DIFF
--- a/src/controllers/DBTablesController/DBTablesController.ts
+++ b/src/controllers/DBTablesController/DBTablesController.ts
@@ -21,9 +21,6 @@ class DBTablesController {
     res.send(row)
   }
 
-  // This seems like it's going to be very difficult. I'm going to hold off on this until later
-  public static createTable() {}
-
   public static async createRow(req, res): Promise<void> {
     const table: any = req.params.table
     const dbModel: any = res.locals.databaseConnection.models[table]
@@ -48,7 +45,18 @@ class DBTablesController {
     const response: any = await DBTablesService.deleteRow(pk, dbModel)
     res.status(response.status).send(response)
   }
+
+  public static async getTableFieldNames(req, res): Promise<void> {
+    debugger
+    const table: any = req.params.table
+    const dbModel: any = res.locals.databaseConnection.models[table]
+    const tableFieldNames: any = await dbModel.describe()
+    res.status(200).send(tableFieldNames)
+  }
   
+  // This seems like it's going to be very difficult. I'm going to hold off on this until later
+  public static createTable() { }
+
 }
 
 export default DBTablesController

--- a/src/controllers/RoutesController.ts
+++ b/src/controllers/RoutesController.ts
@@ -26,6 +26,7 @@ class RoutesController {
   private static registerDBTablesRoutes(): void {
     this.router.get(this.expressAdminArea + '/api/tables', DBTablesController.getTables)
     this.router.get(this.expressAdminArea + '/api/tables/:table', DBTablesController.getTableRows)
+    this.router.get(this.expressAdminArea + '/api/tables/:table/describe', DBTablesController.getTableFieldNames)
     this.router.get(this.expressAdminArea + '/api/tables/:table/:pk', DBTablesController.getTableRowByPk)
     this.router.post(this.expressAdminArea + '/api/tables/:table', DBTablesController.createRow)
     this.router.patch(this.expressAdminArea + '/api/tables/:table/:pk', DBTablesController.updateRow)

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,39 +5,26 @@ import { Admin } from './models/Admin'
 import RoutesController from './controllers/RoutesController'
 import MiddlewareRegisterer from './middlewares/MiddlewareRegisterer/MiddlewareRegisterer'
 import ViewRegisterer from './middlewares/ViewRegisterer/ViewRegisterer'
+import { ModelConfigurator } from './utilities/index'
 
 class ExpressAdminArea {
 
   private static express;
   private static router: Router;
   private static databaseConnection;
-  private static config: object;
   
-  public static init(express: any, databaseUri: string, databaseTables: object, config: object): Router {
+  public static init(express: any, databaseUri: string, databaseTables: object[]): Router {
     this.express = express
     this.router = express.Router()
     this.databaseConnection = new Sequelize(databaseUri)
-    this.config = config
-    this.attachTablesToDbConnection(databaseTables)
+    this.databaseConnection.models = {
+      admin: Admin(this.databaseConnection),
+      ...ModelConfigurator.configureModels(databaseTables)
+    }
     MiddlewareRegisterer.registerMiddlewares(this)
     RoutesController.registerAllRoutes(this.router)
     ViewRegisterer.registerViews(this)
     return this.router
-  }
-
-  /**
-   * TODO: Figure out what to do with these methods below
-   *       They don't feel like they should be directly associated with the 'ExpressAdminArea' class
-   * 
-   * TODO: Should this method return an object of database tables to make accessing specific tables via the
-   *       'req.params' object O(1) instead of an array of objects which is O(n)
-   */
-  private static attachTablesToDbConnection(dbTables: any): void {
-    this.databaseConnection.models = { admin: Admin(this.databaseConnection) }
-    for (let table in dbTables) {
-      const lowerCasedTableName: string = table.toLowerCase()
-      this.databaseConnection.models[lowerCasedTableName] = dbTables[table]
-    }
   }
 
 }

--- a/src/models/Admin.ts
+++ b/src/models/Admin.ts
@@ -27,7 +27,14 @@ const Admin = db => {
           unique: true,
           fields: ['username']
         }
-      ]
+      ],
+      scopes: {
+        expressAdminArea: {
+          attributes: {
+            exclude: ['password']
+          }
+        }
+      }
     }
   )
 

--- a/src/services/DBTablesService/DBTablesService.ts
+++ b/src/services/DBTablesService/DBTablesService.ts
@@ -11,7 +11,7 @@ class DBTablesService {
   public static async getTableRows(model: any): Promise<Object | Array<Object>> {
     let columns: Object | Array<Object> = null
     try {
-      columns = await model.findAll()
+      columns = await model.scope('expressAdminArea').findAll()
     }
     catch (_e) {
       columns = { message: 'No Content', status: 204 }
@@ -24,7 +24,7 @@ class DBTablesService {
     try {
       const rowPk: number = reqParams.pk
       const model: any = dbModel
-      row = await model.findByPk(rowPk) || row
+      row = await model.scope('expressAdminArea').findByPk(rowPk) || row
     }
     catch (_e) {
       row = { message: 'Bad Request', status: 400 }

--- a/src/utilities/ModelConfigurator/ModelConfigurator.ts
+++ b/src/utilities/ModelConfigurator/ModelConfigurator.ts
@@ -1,0 +1,39 @@
+class ModelConfigurator {
+
+  private static models: object[] = null
+
+  public static configureModels(models: object[]): object {
+    ModelConfigurator.setModels(models)
+    ModelConfigurator.addModelScope()
+    return ModelConfigurator.arrayToObject()
+  }
+
+  public static setModels(models: object[]): void {
+    ModelConfigurator.models = models
+  }
+
+  public static addModelScope(): void {
+    const models: object[] = ModelConfigurator.models.map((model: any) => {
+      try {
+        model.model.scope('expressAdminArea')
+      }
+      catch (_e) {
+        model.model.addScope('expressAdminArea', {})
+      }
+      return model
+    })
+    ModelConfigurator.models = models
+  }
+
+  public static arrayToObject(): object {
+    const models: object = {}
+    ModelConfigurator.models.forEach((model: any): void => {
+      const modelNameLowerCase: string = model.model.name.toLowerCase()
+      models[modelNameLowerCase] = model.model
+    })
+    return models
+  }
+
+}
+
+export { ModelConfigurator }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,0 +1,1 @@
+export { ModelConfigurator } from './ModelConfigurator/ModelConfigurator'

--- a/src/views/src/components/CreateNewRowForm/CreateNewRowForm.tsx
+++ b/src/views/src/components/CreateNewRowForm/CreateNewRowForm.tsx
@@ -2,35 +2,28 @@ import React, { Component } from 'react'
 
 type Props = {
   fields: string[]
+  url: string
   createNewDbRow: (inputFields: object) => void
 }
 
-type State = {}
+type State = {
+  fields: string[]
+}
 
 class CreateNewRowForm extends Component<Props, State> {
 
-  inputFields: object|any = {}
-  state: State = {}
+  inputFields: object | any = {}
+  state: State = {
+    fields: []
+  }
 
   render() {
     const createNewDbRow: (inputFields: object) => void = this.props.createNewDbRow
-    const fields: string[] = this.props.fields
-    
+
     return (
       <form onSubmit={e => e.preventDefault()}>
-        {fields.map((field: string): React.ReactNode => {
-          return (
-            <React.Fragment key={field}>
-              <label htmlFor={field}>
-                {field}
-              </label>
-              <input
-                name={field}
-                ref={(input: HTMLInputElement): HTMLInputElement => this.inputFields[field] = input}
-              />
-            </React.Fragment>
-          )
-        })}
+        {this.renderFields()}
+
         <input
           type="submit"
           value="Create New Row"
@@ -38,6 +31,40 @@ class CreateNewRowForm extends Component<Props, State> {
         />
       </form>
     )
+  }
+
+  // render form method
+  public renderFields(): JSX.Element[] {
+    return this.state.fields.map((field: any): any => {
+      return <React.Fragment key={field}>
+        <label htmlFor={field}>
+          {field}
+        </label>
+
+        <input
+          name={field}
+          ref={(input: any): any => this.inputFields[field] = input}
+        />
+      </React.Fragment>
+    })
+  }
+
+  componentDidMount() {
+    this.fetchTableFieldNames()
+  }
+
+  public fetchTableFieldNames(): void {
+    fetch(`/expressadminarea/api${this.props.url}/describe`)
+      .then(res => res.json())
+      .then(fields => {
+        console.log(fields)
+        const fieldsNames: string[] = Object.keys(fields)
+        this.setState({ fields: fieldsNames }, () => {
+          debugger
+          console.log(this.state)
+        })
+      })
+      .catch(err => console.log(err))
   }
 
 }

--- a/src/views/src/components/Table/Table.tsx
+++ b/src/views/src/components/Table/Table.tsx
@@ -34,6 +34,7 @@ class Table extends Component<Props, State> {
         <CreateNewRowForm
           fields={this.state.fields}
           createNewDbRow={this.createNewDbRow.bind(this)}
+          url={this.props.match.url}
         />
 
         {this.shouldErrorElementRender()}


### PR DESCRIPTION
<!-- Remove any unused sections before submitting a pull request -->

### PR Check list
- [x] I am pulling from my own branch and **not** a master branch
- [x] My branch is named appropriately: e.g. `bbenefield89/unit_tests`
- [x] Commit messages are detailed and reference file(s) changed


### Pull Request Description
<!-- Short description about this pull request -->
<!-- If your pull request is in reference to an open issue please add that in the description -->
Allows developers to hide specific database fields from UI using [Sequelize Scopes](http://docs.sequelizejs.com/manual/scopes.html)

Hides the `password` on the `Admin` table from UI. This is by default and is not meant to be shown in the UI. This also prevents users from directly modifying an `Admin` password from `Express Admin Area` but will continue to have the ability to create new `Admin`s from the UI.

### Screenshots
<!-- If a screen short adds value then feel free to attach one here -->